### PR TITLE
Angular5 support: Remove Angular4 dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,20 +33,6 @@
         "verify": "npm run lint && npm run test:node && npm run build && npm run build:prod"
     },
     "private": false,
-    "dependencies": {
-        "@angular/animations": "^4.2.4",
-        "@angular/common": "^4.2.4",
-        "@angular/compiler": "^4.2.4",
-        "@angular/core": "^4.2.4",
-        "@angular/forms": "^4.2.4",
-        "@angular/http": "^4.2.4",
-        "@angular/platform-browser": "^4.2.4",
-        "@angular/platform-browser-dynamic": "^4.2.4",
-        "@angular/router": "^4.2.4",
-        "core-js": "^2.4.1",
-        "rxjs": "^5.4.2",
-        "zone.js": "^0.8.14"
-    },
     "devDependencies": {
         "@angular/cli": "1.3.0",
         "@angular/compiler-cli": "^4.2.4",
@@ -67,6 +53,18 @@
         "protractor": "~5.1.2",
         "ts-node": "~3.2.0",
         "tslint": "~5.3.2",
-        "typescript": "~2.3.3"
+        "typescript": "~2.3.3",
+        "@angular/animations": "^4.2.4",
+        "@angular/common": "^4.2.4",
+        "@angular/compiler": "^4.2.4",
+        "@angular/core": "^4.2.4",
+        "@angular/forms": "^4.2.4",
+        "@angular/http": "^4.2.4",
+        "@angular/platform-browser": "^4.2.4",
+        "@angular/platform-browser-dynamic": "^4.2.4",
+        "@angular/router": "^4.2.4",
+        "core-js": "^2.4.1",
+        "rxjs": "^5.4.2",
+        "zone.js": "^0.8.14"
     }
 }


### PR DESCRIPTION
All `dependencies` of this module are, in fact, just `devDependencies` - and unnecessarily limit angular version to `4.x.x`.

Moving all `dependencies` to `devDependencies` adds additional Angular 5 support.

Solves #11 
Solves #12 