### PR TITLE
Update ng4-files-utils.service.ts

### DIFF
--- a/src/app/ng4-files/services/ng4-files-utils.service.ts
+++ b/src/app/ng4-files/services/ng4-files-utils.service.ts
@@ -57,7 +57,7 @@ export class Ng4FilesUtilsService {
 
             const regexp = Ng4FilesUtilsService.getRegExp(extensionsList);
 
-            return !regexp.test(file.name);
+            return !regexp.test(file.name.toLowerCase()); // for case insensitive extension matching
         });
 
         if (filesNotMatchExtensions.length) {


### PR DESCRIPTION
I have made this change so that the extension matching becomes case insensitive, hence files with extensions 'png' or 'PNG' passes the check.